### PR TITLE
[b/328440720] Adjust expected results when casting STRING to INTEGER

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Tableau Connector SDK Changelog
+## 2024-03-11
+### Changed
+- [b/328440720] Adjust expected results when casting STRING to INTEGER
 ## 2023-04-10
 ### Changed
 - Update `oauth_config.xsd` to include `configLabel` field and update `min-version-tableau` to be 2023.2 if present

--- a/tdvt/tdvt/exprtests/standard/expected.setup.cast.int.nulls.txt
+++ b/tdvt/tdvt/exprtests/standard/expected.setup.cast.int.nulls.txt
@@ -51,16 +51,16 @@
         <value>-14</value>
       </tuple>
       <tuple>
-        <value>3</value>
+        <value>4</value>
       </tuple>
       <tuple>
-        <value>6</value>
+        <value>7</value>
       </tuple>
       <tuple>
         <value>8</value>
       </tuple>
       <tuple>
-        <value>10</value>
+        <value>11</value>
       </tuple>
       <tuple>
         <value>19</value>


### PR DESCRIPTION
As detailed in https://github.com/looker-open-source/calcite/pull/45, we should cast STRINGs to FLOAT64 before casting them to INTEGERs to avoid errors with decimals. This means the whole part of the result is sometimes differs from the original string.
